### PR TITLE
Update Financial Chart and Table to fix their google api loading

### DIFF
--- a/FinancialChart/FinancialChart.xml
+++ b/FinancialChart/FinancialChart.xml
@@ -317,7 +317,6 @@
 
 	    <link rel="stylesheet" href="//s3.amazonaws.com/Common-Production/Settings/css/Settings.css" />
 
-	    <script type="text/javascript" src="//www.google.com/jsapi"></script>
 	    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 
 	    <script type="text/javascript" src="//s3.amazonaws.com/Common-Production/Common/RiseVision.Common.min.js"></script>
@@ -328,8 +327,7 @@
 		    chart = null;
 
                 function init() {
-		    google.setOnLoadCallback(function() {
-			$(function() {
+		    $(function() {
 			    chart = new RiseVision.FinancialChart.Settings();
 
 			    gadgets.rpc.register("rscmd_getSettings", chart.getSettings);
@@ -339,7 +337,6 @@
 
 			    chart.initSettings();
 			});
-		    });
                 }
 
                 gadgets.util.registerOnLoadHandler(init);
@@ -490,7 +487,7 @@
 
 	<link rel="stylesheet" href="//s3.amazonaws.com/Common-Production/envision/css/envision.css" />
 
-	<script type="text/javascript" src="//www.google.com/jsapi"></script>
+    <script type="text/javascript" src="//www.gstatic.com/charts/loader.js"></script>
 	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 
   <script type="text/javascript" src="//s3.amazonaws.com/Common-Production/datejs/date.min.js"></script>
@@ -539,8 +536,7 @@
 		gadgets.rpc.register("rscmd_pause_" + id, pause);
 		gadgets.rpc.register("rscmd_stop_" + id, stop);
 
-		google.setOnLoadCallback(function() {
-		    gadgets.rpc.register("rsparam_set_" + id, function(name, value) {
+		gadgets.rpc.register("rsparam_set_" + id, function(name, value) {
 			if (prefs.getBool("acceptance")) {
 			    initChart(value);
 			}
@@ -552,7 +548,6 @@
 		    });
 
 		    gadgets.rpc.call("", "rsparam_get", null, id, "displayId");
-		});
             }
 
 	    //Initialize the gadget.

--- a/FinancialTable/FinancialTable.xml
+++ b/FinancialTable/FinancialTable.xml
@@ -205,7 +205,6 @@
 
 	    <link rel="stylesheet" href="//s3.amazonaws.com/Common-Production/Settings/css/Settings.css" />
 
-	    <script type="text/javascript" src="//www.google.com/jsapi"></script>
 	    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 
 	    <script type="text/javascript" src="//s3.amazonaws.com/Common-Production/Common/RiseVision.Common.min.js"></script>
@@ -216,8 +215,7 @@
 		    financial = null;
 
                 function init() {
-		    google.setOnLoadCallback(function() {
-			$(function() {
+		    $(function() {
 			    financial = new RiseVision.FinancialSettings();
 
 			    gadgets.rpc.register("rscmd_getSettings", financial.getSettings);
@@ -227,7 +225,6 @@
 
 			    financial.initSettings();
 			});
-		    });
                 }
 
                 gadgets.util.registerOnLoadHandler(init);
@@ -326,7 +323,7 @@
 	</div>
 
 	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-	<script type="text/javascript" src="//www.google.com/jsapi"></script>
+	<script type="text/javascript" src="//www.gstatic.com/charts/loader.js"></script>
 
 	<script type="text/javascript" src="//s3.amazonaws.com/Common-Production/datejs/date.min.js"></script>
 	<script type="text/javascript" src="//s3.amazonaws.com/Common-Production/Common/RiseVision.Common.min.js"></script>


### PR DESCRIPTION
## Description
Ensuring the gadget now loads visualization apis the new and correct way

## Motivation and Context
Google is deprecating old way of loading APIs

## How Has This Been Tested?
Changes have been deployed to S3 production and validated with http://rva.risevision.com/#/PRESENTATION_MANAGE/id=ee1cdb1f-5a45-45e3-9b39-f03174e95f09?cid=e2c7149d-15a2-4159-bbcf-5ee7adf574c1 , presentation name _Financial General Markets_

Settings works correctly. When testing on Preview, the api loading is fixed but there are other unrelated errors and no data is showing:

![image](https://user-images.githubusercontent.com/7407007/84544406-340fa300-accb-11ea-9019-ba69ba017752.png)

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- documentation
