### PR TITLE
Fix google api loading in RSS

### DIFF
--- a/RSS/RSS.xml
+++ b/RSS/RSS.xml
@@ -294,7 +294,7 @@
 
 	    <link rel="stylesheet" href="//s3.amazonaws.com/Common-Production/Settings/css/Settings.css" />
 
-	    <script type="text/javascript" src="//www.google.com/jsapi"></script>
+	    <script type="text/javascript" src="//www.gstatic.com/charts/loader.js"></script>
 	    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 
 	    <script type="text/javascript" src="//s3.amazonaws.com/Common-Production/Common/RiseVision.Common.min.js"></script>
@@ -303,10 +303,7 @@
             <script type="text/javascript">
                 var rssSettings = null;
 
-		google.load("feeds", "1");
-
                 function init() {
-		    google.setOnLoadCallback(function() {
 			$(function() {
 			    rssSettings = new RiseVision.RSS.Settings();
 
@@ -315,7 +312,6 @@
 			    gadgets.rpc.register("rscmd_fontSelectorCallback", rssSettings.setFont);
 
 			    rssSettings.initSettings();
-			});
 		    });
                 }
 


### PR DESCRIPTION
## Description
Ensuring the gadget now loads visualization apis the new and correct way

## Motivation and Context
Google is deprecating old way of loading APIs

## How Has This Been Tested?
- RSS setting works correctly. Tested in [this presentation](https://apps.risevision.com/editor/workspace/4517b427-8695-42db-9d92-8dfc1fad4163?cid=248b818c-d9ed-4e8f-af28-4d00d9159d53).
- Preview shows content.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- documentation
