### PR TITLE
Fix/sports

### DIFF
--- a/sports/sports.xml
+++ b/sports/sports.xml
@@ -67,7 +67,7 @@
   <div id="container">
   </div>
 
-  <script type="text/javascript" src="http://www.google.com/jsapi"></script>
+  <script type="text/javascript" src="http://www.gstatic.com/charts/loader.js"></script>
   <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/swfobject/2.2/swfobject.js"></script>
   <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
   <script type="text/javascript" src="//s3.amazonaws.com/Common-Production/datejs/date.min.js"></script>

--- a/sports/sports.xml
+++ b/sports/sports.xml
@@ -69,6 +69,7 @@
 
   <script type="text/javascript" src="http://www.google.com/jsapi"></script>
   <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/swfobject/2.2/swfobject.js"></script>
+  <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
   <script type="text/javascript" src="//s3.amazonaws.com/Common-Production/datejs/date.min.js"></script>
 
   <script type="text/javascript" src="http://s3.amazonaws.com/Common-Production/Common/RiseVision.Common.min.js"></script>
@@ -95,8 +96,6 @@
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();
-
-      google.load("jquery", "1");
 
             function initialize() {
                 var id = prefs.getString("id");


### PR DESCRIPTION
Changes for sports gadget.

 - `google.load("jquery")` was emitting a deprecation warning
- jsapi change similar to https://github.com/Rise-Vision/gadgets/pull/34

Tested by configuring the gadget in classic editor and previewing.

------

### Config

![sports-config](https://user-images.githubusercontent.com/1511535/84699830-3d457d80-af20-11ea-9c4f-f1f3a4540fa7.png)

------

### Preview

![sports](https://user-images.githubusercontent.com/1511535/84699839-40d90480-af20-11ea-94cf-7fb910b6db49.png)

-----

### Console

![console](https://user-images.githubusercontent.com/1511535/84700048-8c8bae00-af20-11ea-881f-aa137fba09e8.png)
