### PR TITLE
Remove jsapi loader code as it is not used - Photo Album gadget

### DIFF
--- a/PhotoAlbum/PhotoAlbum.xml
+++ b/PhotoAlbum/PhotoAlbum.xml
@@ -106,7 +106,6 @@
 
 	<link rel="stylesheet" href="//s3.amazonaws.com/Gadget-Photo-Album/CoverFlow/css/ContentFlow.css" />
 
-	<script src="//www.gstatic.com/charts/loader.js"></script>
 	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
 
 	<script src="//s3.amazonaws.com/Gadget-Photo-Album/CoverFlow/js/CoverFlow.min.js"></script>

--- a/PhotoAlbum/PhotoAlbum.xml
+++ b/PhotoAlbum/PhotoAlbum.xml
@@ -32,26 +32,26 @@
 		-moz-box-sizing: border-box;
 		box-sizing: border-box;
 	    }
-	    
+
 	    body {
 		background: transparent;
 	    }
-	    
+
 	    #container {
 		width: 100%;
 		height: 100%;
 	    }
-	    
+
 	    .slideInLeft {
 		-webkit-animation-name: slideInLeft;
 		-webkit-animation-duration: 1.2s;
 	    }
-	    
+
 	    .slideOutLeft {
 		-webkit-animation-name: slideOutLeft;
 		-webkit-animation-duration: 1.2s;
 	    }
-	    
+
 	    @-webkit-keyframes slideInLeft {
 		from {
 		    left: __UP_rsW__px;
@@ -60,7 +60,7 @@
 		    left: 0px;
 		}
 	    }
-	    
+
 	    @-webkit-keyframes slideOutLeft {
 		from {
 		    left: 0px;
@@ -69,17 +69,17 @@
 		    left: -__UP_rsW__px;
 		}
 	    }
-	    
+
 	    .slideInRight{
 		-webkit-animation-name: slideInRight;
 		-webkit-animation-duration: 1.2s;
 	    }
-	    
+
 	    .slideOutRight {
 		-webkit-animation-name: slideOutRight;
 		-webkit-animation-duration: 1.2s;
 	    }
-	    
+
 	    @-webkit-keyframes slideInRight {
 		from {
 		    left: -__UP_rsW__px;
@@ -88,7 +88,7 @@
 		    left: 0px;
 		}
 	    }
-	    
+
 	    @-webkit-keyframes slideOutRight {
 		from {
 		    left: 0px;
@@ -97,87 +97,83 @@
 		    left: __UP_rsW__px;
 		}
 	    }
-	    
+
 	    __UP_caption_font-style__
 	</style>
-    
+
 	<div id="container">
 	</div>
-	
+
 	<link rel="stylesheet" href="//s3.amazonaws.com/Gadget-Photo-Album/CoverFlow/css/ContentFlow.css" />
-	
-	<script src="//www.google.com/jsapi"></script>
+
+	<script src="//www.gstatic.com/charts/loader.js"></script>
 	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js"></script>
-    
+
 	<script src="//s3.amazonaws.com/Gadget-Photo-Album/CoverFlow/js/CoverFlow.min.js"></script>
 	<script src="//s3.amazonaws.com/Gadget-Photo-Album/CoverFlow/js/ContentFlow.js"></script>
 	<script src="//s3.amazonaws.com/Common-Production/touchSwipe/jquery.touchSwipe-1.2.2.min.js"></script>
 	<script src="//s3.amazonaws.com/Common-Production/Common/RiseVision.Common.min.js"></script>
 	<script src="//s3.amazonaws.com/Gadget-Photo-Album/PhotoAlbum.min.js"></script>
-    
+
 	<script type="text/javascript">
 	    var prefs = new gadgets.Prefs();
-	    
+
 	    //Issue 1052 - Disable right-click.
 	    window.oncontextmenu = function() {
 		return false;
 	    };
-	    
+
 	    //Add Analytics code.
 	    var _gaq = _gaq || [];
-	    
+
 	    _gaq.push(['_setAccount', 'UA-41395348-18']);
 	    _gaq.push(['_trackPageview']);
-	  
+
 	    (function() {
 		var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
 		ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
 		var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
 	    })();
-	    
-	    google.load("feeds", "1");
-	    
+
 	    function play() {
 		window.photoAlbum.play();
 	    }
-	    
+
 	    function pause() {
 		window.photoAlbum.pause();
 	    }
-	    
+
 	    function stop() {
 		window.photoAlbum.pause();
 	    }
-	    
+
 	    function readyEvent() {
 		gadgets.rpc.call('', 'rsevent_ready', null, prefs.getString("id"), true, true, true, true, true);
 	    }
-	
+
 	    function doneEvent() {
 		gadgets.rpc.call('', 'rsevent_done', null, prefs.getString("id"));
 	    }
-	    
+
 	    function initialize() {
 		var id = prefs.getString("id");
-		var backgroundColor = prefs.getString("backgroundColor");       
-		
+		var backgroundColor = prefs.getString("backgroundColor");
+
 		if (id !== null && id != "") {
 		    gadgets.rpc.register("rscmd_play_" + id, play);
 		    gadgets.rpc.register("rscmd_pause_" + id, pause);
 		    gadgets.rpc.register("rscmd_stop_" + id, stop);
 		}
-		
+
 		if (backgroundColor != "") {
 		    document.body.style.background = backgroundColor;
 		}
-	
-		google.setOnLoadCallback(function() {
-		    window.photoAlbum = new PhotoAlbum();	
-		    window.photoAlbum.initialize();
-		});			
+
+		window.photoAlbum = new PhotoAlbum();
+        window.photoAlbum.initialize();
 	    }
-	
-	    gadgets.util.registerOnLoadHandler(initialize); 		
+
+	    gadgets.util.registerOnLoadHandler(initialize);
 	</script>]]>
     </Content>
 </Module>


### PR DESCRIPTION
## Description
Remove all use of google loader

## Motivation and Context
Photo Album was loading jsapi loader to load "feeds" api which when looking further it wasn't even used. 

## How Has This Been Tested?
Preview and on a display with a simplified presentation just using Photo Album - http://rva.risevision.com/#/PRESENTATION_MANAGE/id=c0fdeee1-5e31-42ac-a07c-157a8695f316?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

** Note** Despite no errors, no photos actually get displayed. The album that was configured is https://picasaweb.google.com/data/feed/base/user/102412259209130620784/albumid/5984795798250895281?alt=rss&kind=photo&authkey=Gv1sRgCKLDt_-J4YS5igE&hl=en_US , however Picasa has since been deprecated for Google Photos, so it's not likely that this gadget was working before google loader issue. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
