### PR TITLE
Remove jsapi in Item Profiler

### DIFF
--- a/ItemProfiler/rd-item-profiler.htm
+++ b/ItemProfiler/rd-item-profiler.htm
@@ -13,7 +13,7 @@
 <script type="text/javascript" src="./js/rd.ip.filter.js"></script>
 <script type="text/javascript" src="./js/rd.ip.keyboard.js"></script>
 <script type="text/javascript" src="./js/rd.ip.data.js"></script>
-<script type="text/javascript" src="https://www.google.com/jsapi?autoload=%7B%22modules%22%3A%5B%7B%22name%22%3A%22visualization%22%2C%22version%22%3A%221%22%7D%5D%7D"></script>
+<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js?autoload=%7B%22modules%22%3A%5B%7B%22name%22%3A%22visualization%22%2C%22version%22%3A%221%22%7D%5D%7D"></script>
 
 <script id="shader-fs" type="x-shader/x-fragment">
     #ifdef GL_ES

--- a/ItemProfiler/rd-item-profiler_3x1.html
+++ b/ItemProfiler/rd-item-profiler_3x1.html
@@ -13,7 +13,7 @@
 <script type="text/javascript" src="http://c921445.r45.cf2.rackcdn.com/rd.ip.filter.js"></script>
 <script type="text/javascript" src="http://c921445.r45.cf2.rackcdn.com/rd.ip.keyboard.js"></script>
 <script type="text/javascript" src="http://c921445.r45.cf2.rackcdn.com/rd.ip.data.js"></script>
-<script type="text/javascript" src="https://www.google.com/jsapi?autoload=%7B%22modules%22%3A%5B%7B%22name%22%3A%22visualization%22%2C%22version%22%3A%221%22%7D%5D%7D"></script>
+<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js?autoload=%7B%22modules%22%3A%5B%7B%22name%22%3A%22visualization%22%2C%22version%22%3A%221%22%7D%5D%7D"></script>
 
 <script id="shader-fs" type="x-shader/x-fragment">
     #ifdef GL_ES


### PR DESCRIPTION
Remove jsapi in Item Profiler. The gadget settings were not affected by this change - only rendering on a display. This change gets rid of errors, but unfortunatelly rendering is still not working. It's hard to say if rendering was broken for a long time or if it stopped working because of jsapi. Even though this change does not fully fix the problem, I think it's still a good idea to have in the code.

@stulees could you please review?
