### PR TITLE
Remove unnecessary loader.js from RSS

### DIFF
--- a/RSS/RSS.xml
+++ b/RSS/RSS.xml
@@ -294,7 +294,6 @@
 
 	    <link rel="stylesheet" href="//s3.amazonaws.com/Common-Production/Settings/css/Settings.css" />
 
-	    <script type="text/javascript" src="//www.gstatic.com/charts/loader.js"></script>
 	    <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 
 	    <script type="text/javascript" src="//s3.amazonaws.com/Common-Production/Common/RiseVision.Common.min.js"></script>


### PR DESCRIPTION
Remove unnecessary link for loading `loader.js` as mentioned in https://github.com/Rise-Vision/gadgets/pull/34. 

The change is deployed to S3. I verified that gadget setting are working.

@alex-deaconu could you please review? Thanks.